### PR TITLE
Fix Closed Drafts stay open

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -6,7 +6,7 @@ class PullRequest < GnosisApplicationRecord
 
   def self.auto_create_or_update(webhook_params)
     state = webhook_params[:pull_request][:merged] ? 'merged' : webhook_params[:pull_request][:state]
-    state = 'draft' if webhook_params[:pull_request][:draft]
+    state = 'draft' if state == 'open' && webhook_params[:pull_request][:draft]
 
     return if Issue.find_by(id: webhook_params[:issue_id]).nil?
 

--- a/test/unit/pull_request_test.rb
+++ b/test/unit/pull_request_test.rb
@@ -42,4 +42,16 @@ class PullRequestTest < ActiveSupport::TestCase
     pr = PullRequest.last
     assert_equal 'open', pr.state
   end
+
+  def test_closed_draft_pull_request_state
+    webhook_hash = @github_webhook_hash.dup
+    webhook_hash[:pull_request][:state] = 'closed'
+    webhook_hash[:pull_request][:draft] = true
+    webhook_hash[:pull_request][:merged] = false
+
+    PullRequest.auto_create_or_update(webhook_hash)
+
+    pr = PullRequest.find_by(url: webhook_hash[:pull_request][:html_url])
+    assert_equal 'closed', pr.state
+  end
 end


### PR DESCRIPTION
[TICKET-22742](https://redmine.renuo.ch/issues/22742)

This PR adds a check to see whether a given PR is still open before setting it's status to "draft". If it was closed, it will set the state to `webhook_params[:pull_request][:state]`, which would be "closed", as stated in [this page of the GitHub Documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request) (scroll down to the body parameters and open the dropdown for `pull_request`'s properties, and have a look at the `state` attribute).