### PR TITLE
Fix stale webhook overwrites

### DIFF
--- a/app/models/gnosis/pull_request.rb
+++ b/app/models/gnosis/pull_request.rb
@@ -14,7 +14,7 @@ module Gnosis
 
       pr = PullRequest.find_or_initialize_by(url: pull_request_data[:html_url])
       github_updated_at = pull_request_data[:updated_at] && Time.zone.parse(pull_request_data[:updated_at].to_s)
-      return if pr.persisted? && github_updated_at && pr.github_updated_at.present? && github_updated_at <= pr.github_updated_at
+      return if stale_webhook?(pr, github_updated_at)
 
       pr.update!(state: state,
                  url: pull_request_data[:html_url],
@@ -25,6 +25,12 @@ module Gnosis
                  merge_commit_sha: pull_request_data[:merge_commit_sha],
                  github_updated_at: github_updated_at || pr.github_updated_at,
                  issue_id: webhook_params[:issue_id])
+    end
+
+    def self.stale_webhook?(pull_request, github_updated_at)
+      return false unless pull_request.persisted? && github_updated_at && pull_request.github_updated_at.present?
+
+      github_updated_at <= pull_request.github_updated_at
     end
   end
 end

--- a/app/models/gnosis/pull_request.rb
+++ b/app/models/gnosis/pull_request.rb
@@ -6,19 +6,24 @@ module Gnosis
     has_many :pull_request_deployments, dependent: :destroy
 
     def self.auto_create_or_update(webhook_params)
-      state = webhook_params[:pull_request][:merged] ? 'merged' : webhook_params[:pull_request][:state]
-      state = 'draft' if state == 'open' && webhook_params[:pull_request][:draft]
+      pull_request_data = webhook_params[:pull_request]
 
+      state = pull_request_data[:merged] ? 'merged' : pull_request_data[:state]
+      state = 'draft' if state == 'open' && pull_request_data[:draft]
       return if Issue.find_by(id: webhook_params[:issue_id]).nil?
 
-      pr = PullRequest.find_or_initialize_by(url: webhook_params[:pull_request][:html_url])
+      pr = PullRequest.find_or_initialize_by(url: pull_request_data[:html_url])
+      github_updated_at = pull_request_data[:updated_at] && Time.zone.parse(pull_request_data[:updated_at].to_s)
+      return if pr.persisted? && github_updated_at && pr.github_updated_at.present? && github_updated_at <= pr.github_updated_at
+
       pr.update!(state: state,
-                 url: webhook_params[:pull_request][:html_url],
-                 title: webhook_params[:pull_request][:title],
-                 source_branch: webhook_params[:pull_request][:head][:ref],
-                 target_branch: webhook_params[:pull_request][:base][:ref],
-                 was_merged: webhook_params[:pull_request][:merged],
-                 merge_commit_sha: webhook_params[:pull_request][:merge_commit_sha],
+                 url: pull_request_data[:html_url],
+                 title: pull_request_data[:title],
+                 source_branch: pull_request_data[:head][:ref],
+                 target_branch: pull_request_data[:base][:ref],
+                 was_merged: pull_request_data[:merged],
+                 merge_commit_sha: pull_request_data[:merge_commit_sha],
+                 github_updated_at: github_updated_at || pr.github_updated_at,
                  issue_id: webhook_params[:issue_id])
     end
   end

--- a/app/services/gnosis/pull_request_sync_service.rb
+++ b/app/services/gnosis/pull_request_sync_service.rb
@@ -16,7 +16,7 @@ module Gnosis
     end
 
     def fetch_repositories
-      client.org_repositories(ENV.fetch('GITHUB_ORGANIZATION_NAME'), type: :private)
+      client.org_repositories(ENV.fetch('GITHUB_ORGANIZATION_NAME'), type: :all)
     end
 
     def fetch_repository_pull_requests(repository)

--- a/db/migrate/20260706000000_add_github_updated_at_to_pull_requests.rb
+++ b/db/migrate/20260706000000_add_github_updated_at_to_pull_requests.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGithubUpdatedAtToPullRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :gnosis_pull_requests, :github_updated_at, :datetime
+  end
+end

--- a/test/unit/pull_request_test.rb
+++ b/test/unit/pull_request_test.rb
@@ -3,6 +3,9 @@
 require_relative '../test_helper'
 
 class PullRequestTest < ActiveSupport::TestCase
+  EARLIER = '2024-01-01T10:00:00Z'
+  LATER = '2024-01-01T11:00:00Z'
+
   def setup
     @github_webhook_hash = {
       pull_request: {
@@ -16,7 +19,8 @@ class PullRequestTest < ActiveSupport::TestCase
           ref: 'main'
         },
         merged: true,
-        merge_commit_sha: '19a89f0050eacf201ccd058d5e28cddf2b035bfc'
+        merge_commit_sha: '19a89f0050eacf201ccd058d5e28cddf2b035bfc',
+        updated_at: LATER
       },
       issue_id: 1
     }
@@ -29,25 +33,52 @@ class PullRequestTest < ActiveSupport::TestCase
 
     pr = Gnosis::PullRequest.last
     assert_equal 'merged', pr.state
+    assert_equal Time.zone.parse(LATER), pr.github_updated_at
   end
 
   def test_update_pull_request
-    Gnosis::PullRequest.auto_create_or_update(@github_webhook_hash)
-    @github_webhook_hash[:pull_request][:state] = 'open'
-    @github_webhook_hash[:pull_request][:merged] = false
+    webhook_hash = @github_webhook_hash.dup
+    webhook_hash[:pull_request] = webhook_hash[:pull_request].merge(state: 'open', merged: false, updated_at: EARLIER)
+
+    Gnosis::PullRequest.auto_create_or_update(webhook_hash)
+    webhook_hash[:pull_request] = webhook_hash[:pull_request].merge(state: 'closed', merged: false, updated_at: LATER)
     assert_difference('Gnosis::PullRequest.count', 0) do
-      Gnosis::PullRequest.auto_create_or_update(@github_webhook_hash)
+      Gnosis::PullRequest.auto_create_or_update(webhook_hash)
     end
 
     pr = Gnosis::PullRequest.last
-    assert_equal 'open', pr.state
+    assert_equal 'closed', pr.state
+  end
+
+  def test_out_of_order_webhook_does_not_overwrite_a_newer_state
+    Gnosis::PullRequest.auto_create_or_update(@github_webhook_hash) # merged, at LATER
+
+    stale_hash = @github_webhook_hash.dup
+    stale_hash[:pull_request] = stale_hash[:pull_request].merge(state: 'open', merged: false, updated_at: EARLIER)
+    assert_difference('Gnosis::PullRequest.count', 0) do
+      Gnosis::PullRequest.auto_create_or_update(stale_hash)
+    end
+
+    pr = Gnosis::PullRequest.last
+    assert_equal 'merged', pr.state
+  end
+
+  def test_out_of_order_webhook_does_not_reopen_a_more_recently_closed_pull_request
+    webhook_hash = @github_webhook_hash.dup
+    webhook_hash[:pull_request] = webhook_hash[:pull_request].merge(state: 'closed', merged: false, updated_at: LATER)
+    Gnosis::PullRequest.auto_create_or_update(webhook_hash)
+
+    stale_hash = @github_webhook_hash.dup
+    stale_hash[:pull_request] = stale_hash[:pull_request].merge(state: 'open', merged: false, updated_at: EARLIER)
+    Gnosis::PullRequest.auto_create_or_update(stale_hash)
+
+    pr = Gnosis::PullRequest.last
+    assert_equal 'closed', pr.state
   end
 
   def test_closed_draft_pull_request_state
     webhook_hash = @github_webhook_hash.dup
-    webhook_hash[:pull_request][:state] = 'closed'
-    webhook_hash[:pull_request][:draft] = true
-    webhook_hash[:pull_request][:merged] = false
+    webhook_hash[:pull_request] = webhook_hash[:pull_request].merge(state: 'closed', draft: true, merged: false)
 
     Gnosis::PullRequest.auto_create_or_update(webhook_hash)
 

--- a/test/unit/webhook_handler_test.rb
+++ b/test/unit/webhook_handler_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class WebhookHandlerTest < ActiveSupport::TestCase
+  def setup
+    @github_webhook_hash = {
+      pull_request: {
+        state: 'open',
+        html_url: 'https://github.com/aneshodza/test-repo/pull/17',
+        title: 'Create something',
+        head: {
+          ref: 'feature/1-some-feature'
+        },
+        base: {
+          ref: 'main'
+        },
+        merged: false,
+        merge_commit_sha: '19a89f0050eacf201ccd058d5e28cddf2b035bfc'
+      }
+    }
+  end
+
+  def test_handle_github_creates_pull_request_for_existing_issue
+    assert_difference('Gnosis::PullRequest.count', 1) do
+      Gnosis::WebhookHandler.new.handle_github(@github_webhook_hash)
+    end
+  end
+
+  def test_handle_github_skips_when_no_issue_number_can_be_extracted
+    @github_webhook_hash[:pull_request][:head][:ref] = 'feature/some-feature-no-issue'
+    assert_no_difference('Gnosis::PullRequest.count') do
+      Gnosis::WebhookHandler.new.handle_github(@github_webhook_hash)
+    end
+  end
+
+  def test_handle_github_skips_when_extracted_issue_does_not_exist
+    @github_webhook_hash[:pull_request][:head][:ref] = 'feature/999999-no-such-issue'
+    assert_no_difference('Gnosis::PullRequest.count') do
+      Gnosis::WebhookHandler.new.handle_github(@github_webhook_hash)
+    end
+  end
+end


### PR DESCRIPTION
TICKET-26001

Stale/out of order webhooks could revert PR state. GitHub doesn't guarantee webhook delivery order, so a delayed or retried delivery could silently flip a PR's state backwards (as it probably did for the open PR [here](https://redmine.renuo.ch/issues/24939)). With this we now store GitHub's own `updated_at` per PR and ignore any incoming webhook that's older than what's already stored